### PR TITLE
Fix rubocop for addresses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -105,3 +105,6 @@ Metrics/MethodLength:
 Naming/PredicateName:
   Exclude:
     - lib/cryptopay/models/**/*
+
+Naming/VariableNumber:
+  AllowedIdentifiers: line_1, line_2


### PR DESCRIPTION
Allow to use line_1 and line_2 identifiers